### PR TITLE
fix accurate g-buffer normals

### DIFF
--- a/Shaders/NormalSample.hlsl
+++ b/Shaders/NormalSample.hlsl
@@ -1,0 +1,52 @@
+#ifndef LIMSSR_NORMAL_SAMPLE_INCLUDED
+#define LIMSSR_NORMAL_SAMPLE_INCLUDED
+
+#pragma multi_compile _ _GBUFFER_NORMALS_OCT
+
+//#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Packing.hlsl"
+
+// Unpack 2 float of 12bit packed into a 888
+float2 Unpack888UIntToFloat2(uint3 x)
+{
+				// 8 bit in lo, 4 bit in hi
+    uint hi = x.z >> 4;
+    uint lo = x.z & 15;
+    uint2 cb = x.xy | uint2(lo << 8, hi << 8);
+
+    return cb / 4095.0;
+}
+
+			// Unpack 2 float of 12bit packed into a 888
+float2 Unpack888ToFloat2(float3 x)
+{
+    uint3 i = (uint3) (x * 255.5); // +0.5 to fix precision error on iOS
+    return Unpack888UIntToFloat2(i);
+}
+float3 UnpackNormalOctQuadEncode(float2 f)
+{
+    float3 n = float3(f.x, f.y, 1.0 - abs(f.x) - abs(f.y));
+
+				//float2 val = 1.0 - abs(n.yx);
+				//n.xy = (n.zz < float2(0.0, 0.0) ? (n.xy >= 0.0 ? val : -val) : n.xy);
+
+				// Optimized version of above code:
+    float t = max(-n.z, 0.0);
+    n.xy += n.xy >= 0.0 ? -t.xx : t.xx;
+
+    return normalize(n);
+}
+
+float3 UnpackNormal(float3 normal)
+{
+#if defined(_GBUFFER_NORMALS_OCT)
+    float2 remappedOctNormalWS = Unpack888ToFloat2(normal); // values between [ 0,  1]
+    float2 octNormalWS = remappedOctNormalWS.xy * 2.0 - 1.0;    // values between [-1, +1]
+    normal = UnpackNormalOctQuadEncode(octNormalWS);
+#else
+    normal = normalize(normal);
+#endif
+    
+    return normal;
+}
+
+#endif

--- a/Shaders/NormalSample.hlsl.meta
+++ b/Shaders/NormalSample.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9e460949f6163ff46a30af94f32088e2
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Shaders/ssr_shader.shader
+++ b/Shaders/ssr_shader.shader
@@ -20,6 +20,7 @@ Shader "Hidden/ssr_shader"
             #pragma shader_feature_local TEMPORAL
 
             #include "UnityCG.cginc"
+			#include "NormalSample.hlsl"
 
             struct appdata
             {
@@ -87,7 +88,8 @@ Shader "Hidden/ssr_shader"
                 float4 gbuff = tex2D(_GBuffer2, i.uv);
                 float smoothness = gbuff.w;
                 float stepS = smoothstep(minSmoothness, 1, smoothness);
-                float3 normal = normalize(gbuff.xyz);
+                //float3 normal = normalize(gbuff.xyz);
+				float3 normal = UnpackNormal(gbuff.xyz);
 
                 float4 clipSpace = float4(i.uv * 2 - 1, rawDepth, 1);
                 float4 viewSpacePosition = mul(_InverseProjectionMatrix, clipSpace);
@@ -208,7 +210,8 @@ Shader "Hidden/ssr_shader"
                     }
 
                     //remove backface intersections
-                    float3 currentNormal = tex2D(_GBuffer2, currentScreenSpacePosition).xyz;
+                    //float3 currentNormal = tex2D(_GBuffer2, currentScreenSpacePosition).xyz;
+					float3 currentNormal = UnpackNormal(tex2D(_GBuffer2, currentScreenSpacePosition).xyz);
                     float backFaceDot = dot(currentNormal, reflectionRay);
                     [flatten]
                     if (backFaceDot > 0) {
@@ -239,6 +242,7 @@ Shader "Hidden/ssr_shader"
             #pragma shader_feature_local TEMPORAL
 
             #include "UnityCG.cginc"
+			#include "NormalSample.hlsl"
 
             struct appdata
             {
@@ -302,6 +306,7 @@ Shader "Hidden/ssr_shader"
                 float4 maint = tex2D(_MainTex, i.uv);
                 float4 reflectedUv = tex2D(_ReflectedColorMap, i.uv);
                 float4 normal = tex2D(_GBuffer2, i.uv);
+				normal.xyz = UnpackNormal(normal.xyz);
                 normal = mul(_ViewMatrix, float4(normal.xyz,0));
                 normal = mul(_ProjectionMatrix, float4(normal.xyz,0));
                 normal.y *= -1;
@@ -346,6 +351,7 @@ Shader "Hidden/ssr_shader"
             #define MAX_ITERATIONS 256
 
             #include "UnityCG.cginc"
+			#include "NormalSample.hlsl"
 
             struct appdata
             {
@@ -553,7 +559,8 @@ Shader "Hidden/ssr_shader"
                     return float4(i.uv.xy, 0, 0);
                 }
                 float stepS = smoothstep(minSmoothness, 1, smoothness);
-                float3 normal = normalize(gbuff.xyz);
+                //float3 normal = normalize(gbuff.xyz);
+				float3 normal = UnpackNormal(gbuff.xyz);
 
                 float4 clipSpace = float4(i.uv * 2 - 1, rawDepth, 1);
                 clipSpace.y *= -1;
@@ -597,7 +604,8 @@ Shader "Hidden/ssr_shader"
                 mask *= hit * edgeMask;
 
                 //remove backface intersections
-                float3 currentNormal = tex2D(_GBuffer2, intersectPoint.xy).xyz;
+                //float3 currentNormal = tex2D(_GBuffer2, intersectPoint.xy).xyz;
+				float3 currentNormal = UnpackNormal(tex2D(_GBuffer2, intersectPoint.xy).xyz);
                 float backFaceDot = dot(currentNormal, reflectionRay_w);
                 mask = backFaceDot > 0 && !isSky ? 0 : mask;
 


### PR DESCRIPTION
This update fixes LimSSR to work when URP accurate G-Buffer normals is enabled. 
I have created a new include file, NormalSample.hlsl. This file includes methods taken from urps Packing.hlsl, as well as a keyword for an extra variant (#pragma multi_compile _ _GBUFFER_NORMALS_OCT)

In your original ssr_shader, sometimes you are normalizing the normals obtained form gbuffer2.xyz, and sometimes you are not. I suspect the normalizations may not be needed anywhere, but just in case, I continue normalize it (see screenshot below). I am normalizing all of the Gbuffer2.xyz samples (instead of just a few) just for code cleanliness, so it is worth checking if it is needed at all for other versions.

![Screenshot_7](https://user-images.githubusercontent.com/59656122/230205026-e39f3d56-b86c-414e-a62d-654a77c4cf7f.png)
